### PR TITLE
page:before hook should return page

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
     hooks: {
         'page:before': function (page) {
             pagePath = path.parse(page.rawPath);
+            return page;
         }
     },
     blocks: {


### PR DESCRIPTION
If page:before hook doesn't return page it breaks other plugins.